### PR TITLE
Fix up ordering in env-init.sh and add checks for openshift project.

### DIFF
--- a/introduction/port-forwarding/env-init.sh
+++ b/introduction/port-forwarding/env-init.sh
@@ -1,5 +1,5 @@
 ssh root@host01 "yum install -y postgresql socat"
-ssh root@host01 'for i in {1..200}; do oc policy add-role-to-user system:image-puller system:anonymous && break || sleep 1; done'
 ssh root@host01 "docker pull centos/postgresql-95-centos7:latest"
+ssh root@host01 'for i in {1..200}; do oc policy add-role-to-user system:image-puller system:anonymous && break || sleep 1; done'
 ssh root@host01 'for i in {1..200}; do oc get project/openshift && break || sleep 1; done'
 ssh root@host01 "oc create -f https://raw.githubusercontent.com/openshift/origin/master/examples/db-templates/postgresql-ephemeral-template.json -n openshift"

--- a/introduction/port-forwarding/env-init.sh
+++ b/introduction/port-forwarding/env-init.sh
@@ -1,4 +1,5 @@
-ssh root@host01 "oc create -f https://raw.githubusercontent.com/openshift/origin/master/examples/db-templates/postgresql-ephemeral-template.json -n openshift"
-ssh root@host01 "docker pull centos/postgresql-95-centos7:latest"
 ssh root@host01 "yum install -y postgresql socat"
 ssh root@host01 'for i in {1..200}; do oc policy add-role-to-user system:image-puller system:anonymous && break || sleep 1; done'
+ssh root@host01 "docker pull centos/postgresql-95-centos7:latest"
+ssh root@host01 'for i in {1..200}; do oc get project/openshift && break || sleep 1; done'
+ssh root@host01 "oc create -f https://raw.githubusercontent.com/openshift/origin/master/examples/db-templates/postgresql-ephemeral-template.json -n openshift"

--- a/introduction/service-binding/env-init.sh
+++ b/introduction/service-binding/env-init.sh
@@ -2,4 +2,5 @@ ssh root@host01 'for i in {1..200}; do oc policy add-role-to-user system:image-p
 ssh root@host01 "mkdir -p /data/pv-01 /data/pv-02 /data/pv-03 /data/pv-04 /data/pv-05 /data/pv-06 /data/pv-07 /data/pv-08 /data/pv-09 /data/pv-10"
 ssh root@host01 "chmod 0777 /data/pv-*"
 ssh root@host01 "oc create -f volumes.json"
+ssh root@host01 'for i in {1..200}; do oc get project/openshift && break || sleep 1; done'
 ssh root@host01 "oc create -f https://github.com/openshift/origin/raw/release-3.6/examples/db-templates/postgresql-persistent-template.json -n openshift"

--- a/introduction/training-workshop/env-init.sh
+++ b/introduction/training-workshop/env-init.sh
@@ -3,6 +3,7 @@ ssh root@host01 'oc adm policy add-cluster-role-to-group sudoer system:authentic
 ssh root@host01 "mkdir -p /data/pv-01 /data/pv-02 /data/pv-03 /data/pv-04 /data/pv-05 /data/pv-06 /data/pv-07 /data/pv-08 /data/pv-09 /data/pv-10"
 ssh root@host01 "chmod 0777 /data/pv-*"
 ssh root@host01 "oc create -f volumes.json"
+ssh root@host01 'for i in {1..200}; do oc get project/openshift && break || sleep 1; done'
 ssh root@host01 "oc create -f https://github.com/openshift/origin/raw/release-3.6/examples/db-templates/mongodb-persistent-template.json -n openshift"
 ssh root@host01 "oc create -f https://github.com/openshift/origin/raw/release-3.6/examples/db-templates/mongodb-ephemeral-template.json -n openshift"
 ssh root@host01 "oc create -f https://github.com/openshift/origin/raw/release-3.6/examples/db-templates/mariadb-persistent-template.json -n openshift"

--- a/introduction/transferring-files/env-init.sh
+++ b/introduction/transferring-files/env-init.sh
@@ -1,6 +1,6 @@
-ssh root@host01 "mkdir -p /data/pv-01 /data/pv-02"
-ssh root@host01 "chmod 0777 /data/pv-01 /data/pv-02"
-ssh root@host01 "oc create -f volumes.json"
 ssh root@host01 "docker pull openshiftkatacoda/blog-django-py:latest"
 ssh root@host01 "docker pull centos/httpd-24-centos7:latest"
 ssh root@host01 'for i in {1..200}; do oc policy add-role-to-user system:image-puller system:anonymous && break || sleep 1; done'
+ssh root@host01 "mkdir -p /data/pv-01 /data/pv-02"
+ssh root@host01 "chmod 0777 /data/pv-01 /data/pv-02"
+ssh root@host01 "oc create -f volumes.json"


### PR DESCRIPTION
This is principally to avoid problems with templates not being loaded due to openshift project being slow to be created. The launch.sh and env-init.sh files actually run in parallel and openshift project is created from launch.sh but want to load templates into it from env-init.sh.