### PR TITLE
Address ordering issues with env-init.sh.

### DIFF
--- a/introduction/port-forwarding/env-init.sh
+++ b/introduction/port-forwarding/env-init.sh
@@ -1,5 +1,6 @@
+ssh root@host01 'for i in {1..200}; do oc policy add-role-to-user system:image-puller system:anonymous && break || sleep 1; done'
+ssh root@host01 'oc adm policy add-cluster-role-to-group sudoer system:authenticated'
+ssh root@host01 'for i in {1..200}; do oc get project/openshift --as system:admin && break || sleep 1; done'
+ssh root@host01 "oc create -f https://github.com/openshift/origin/raw/release-3.6/examples/db-templates/postgresql-ephemeral-template.json -n openshift"
 ssh root@host01 "yum install -y postgresql socat"
 ssh root@host01 "docker pull centos/postgresql-95-centos7:latest"
-ssh root@host01 'for i in {1..200}; do oc policy add-role-to-user system:image-puller system:anonymous && break || sleep 1; done'
-ssh root@host01 'for i in {1..200}; do oc get project/openshift && break || sleep 1; done'
-ssh root@host01 "oc create -f https://github.com/openshift/origin/raw/release-3.6/examples/db-templates/postgresql-ephemeral-template.json -n openshift"

--- a/introduction/port-forwarding/env-init.sh
+++ b/introduction/port-forwarding/env-init.sh
@@ -2,4 +2,4 @@ ssh root@host01 "yum install -y postgresql socat"
 ssh root@host01 "docker pull centos/postgresql-95-centos7:latest"
 ssh root@host01 'for i in {1..200}; do oc policy add-role-to-user system:image-puller system:anonymous && break || sleep 1; done'
 ssh root@host01 'for i in {1..200}; do oc get project/openshift && break || sleep 1; done'
-ssh root@host01 "oc create -f https://raw.githubusercontent.com/openshift/origin/master/examples/db-templates/postgresql-ephemeral-template.json -n openshift"
+ssh root@host01 "oc create -f https://github.com/openshift/origin/raw/release-3.6/examples/db-templates/postgresql-ephemeral-template.json -n openshift"

--- a/playgrounds/openshift36/env-init.sh
+++ b/playgrounds/openshift36/env-init.sh
@@ -3,6 +3,7 @@ ssh root@host01 'oc adm policy add-cluster-role-to-group sudoer system:authentic
 ssh root@host01 "mkdir -p /data/pv-01 /data/pv-02 /data/pv-03 /data/pv-04 /data/pv-05 /data/pv-06 /data/pv-07 /data/pv-08 /data/pv-09 /data/pv-10"
 ssh root@host01 "chmod 0777 /data/pv-*"
 ssh root@host01 "oc create -f volumes.json"
+ssh root@host01 'for i in {1..200}; do oc get project/openshift && break || sleep 1; done'
 ssh root@host01 "oc create -f https://github.com/openshift/origin/raw/release-3.6/examples/db-templates/mariadb-ephemeral-template.json -n openshift"
 ssh root@host01 "oc create -f https://github.com/openshift/origin/raw/release-3.6/examples/db-templates/mariadb-persistent-template.json -n openshift"
 ssh root@host01 "oc create -f https://github.com/openshift/origin/raw/release-3.6/examples/db-templates/mongodb-ephemeral-template.json -n openshift"

--- a/playgrounds/openshift37/env-init.sh
+++ b/playgrounds/openshift37/env-init.sh
@@ -3,6 +3,7 @@ ssh root@host01 'oc adm policy add-cluster-role-to-group sudoer system:authentic
 ssh root@host01 "mkdir -p /data/pv-01 /data/pv-02 /data/pv-03 /data/pv-04 /data/pv-05 /data/pv-06 /data/pv-07 /data/pv-08 /data/pv-09 /data/pv-10"
 ssh root@host01 "chmod 0777 /data/pv-*"
 ssh root@host01 "oc create -f volumes.json"
+ssh root@host01 'for i in {1..200}; do oc get project/openshift && break || sleep 1; done'
 ssh root@host01 "oc create -f https://github.com/openshift/origin/raw/release-3.7/examples/db-templates/mariadb-ephemeral-template.json -n openshift"
 ssh root@host01 "oc create -f https://github.com/openshift/origin/raw/release-3.7/examples/db-templates/mariadb-persistent-template.json -n openshift"
 ssh root@host01 "oc create -f https://github.com/openshift/origin/raw/release-3.7/examples/db-templates/mongodb-ephemeral-template.json -n openshift"


### PR DESCRIPTION
The env-init.sh runs in parallel to user doing stuff. If user logs in quickly it can prevent commands running as no longer admin. This PR addresses that for port forwarding example by using impersonation to run things as admin. Will need to do similar for all other scenarios.